### PR TITLE
Etwas eleganter in der Darstellung.

### DIFF
--- a/PreTest1.1.Rmd
+++ b/PreTest1.1.Rmd
@@ -1,46 +1,17 @@
 ---
-title: "R Notebook"
+title: "226305 Projekt Parteispenden"
 output: html_notebook
 ---
 
-This is an [R Markdown](http://rmarkdown.rstudio.com) Notebook. When you execute code within the notebook, the results appear beneath the code. 
+library("igraph")
 
-Try executing this chunk by clicking the *Run* button within the chunk or by placing your cursor inside it and pressing *Cmd+Shift+Enter*. 
+# Daten einlesen
+edges <- read.csv("https://raw.githubusercontent.com/Maxshh/Lobby-/master/226305_Parteispenden_Edgelist.csv", header=T, as.is=T, sep=",")
+nodes <- read.csv("https://raw.githubusercontent.com/Maxshh/Lobby-/master/226305_Parteispenden_Notelist.csv", header=T, as.is=T, sep=",")
 
-```{r}
-library(igraph)
-library(igraphdata)
-
-
-getwd()
-
-edges <- read.csv("Edgelist1.1 - Tabellenblatt1.csv", header=T, as.is=T, sep=",")
-edges
-head(edges)
-
-nodes <- read.csv("Nodelist1.0 - Tabellenblatt1.csv", header=T, as.is=T, sep=",")
 ties <- as.matrix(edges)
+lobbytest <- graph_from_data_frame(d=edges, vertices=nodes, directed=TRUE)
 
-
-
-PreTest1 <- graph_from_data_frame(d=edges, vertices=nodes, directed=TRUE)
-
-PreTest1
-head(nodes)
-
-plot(PreTest1)
-
-This is an [R Markdown](http://rmarkdown.rstudio.com) Notebook. When you execute code within the notebook, the results appear beneath the code. 
-
-Try executing this chunk by clicking the *Run* button within the chunk or by placing your cursor inside it and pressing *Cmd+Shift+Enter*. 
-
-```{r}
-
-```
-
-Add a new chunk by clicking the *Insert Chunk* button on the toolbar or by pressing *Cmd+Option+I*.
-
-When you save the notebook, an HTML file containing the code and output will be saved alongside it (click the *Preview* button or press *Cmd+Shift+K* to preview the HTML file). 
-
-The preview shows you a rendered HTML copy of the contents of the editor. Consequently, unlike *Knit*, *Preview* does not run any R code chunks. Instead, the output of the chunk when it was last run in the editor is displayed.
+# Erste Visualisierung
+plot(lobbytest, layout=layout_in_circle)
 


### PR DESCRIPTION
Bitte die Edge-Weights anpassen und nur für die Eurobeträge nur volle Zahlen verwenden (ohne Cent). 
Sie können das einfach in google Table korrigieren, in dem Sie das Format für die Zahl ändern.
Ansonsten können Sie das Edge-Weight nicht darstellen.

Ausserdem würde ich noch den vollen Namen der Spenderorganisation in die Nodelist aufnehmen.

sws